### PR TITLE
Add Sandbox and renew OAuth tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# E*TRADE OAuth token cache
+.etrade_oauth
+
+# JSON Output
+*.json

--- a/README.md
+++ b/README.md
@@ -1,36 +1,45 @@
 # pyetrade_option_chains
-exemplar code to download all option chains for a symbol using pyetrade (V1 Etrade API).
+
+Exemplar code to download all option chains for a symbol using pyetrade (V1 Etrade API).
 This simple example code demonstrates how to grab credentials and download all the option chains
 from a single symbol and convert the etrade API response to common python dictionaries and lists.
 
 Remember to fill in your personalized values for consumer_key and consumer_secret.
 You need to request user keys for the "production environment" from Etrade. This is a 3-5 day process.
 The "development environment" keys are only useful if you're developing code and want to test against a
-dummy environment.
+dummy environment. See [E*TRADE's Getting Started guide](https://developer.etrade.com/getting-started).
 
 Pyetrade has a number of pretty standard dependencies, including requests, requests_oauthlib, xmltodict
 
-INSTALL:
+## Install
 
-    git clone https://github.com/jessecooper/pyetrade.git
-    cd pyetrade
-    git checkout dev
-    pip install --user setup.py
+```shell
+git clone https://github.com/1rocketdude/pyetrade_option_chains.git
+cd pyetrade_option_chains
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
 
-    cd ..
-    git clone https://github.com/1rocketdude/pyetrade_option_chains.git
+## Usage
 
-USAGE: to download all the option chains for AAPL and save into a JSON file named AAPL-YYYY-MM-DD.json
-    cd pyetrade_option_chains
+To download all the option chains for AAPL and save into a JSON file named
+"AAPL_chains_YYYYMMDD-HHMMSS.json":
 
-    modify consumer_key and consumer_secret in etrade_option_chains.py
-    pyetrade_option_chains.py aapl
+* Modify `KEYS` etrade_option_chains.py
+* Run `./etrade_option_chains.py aapl` or `./etrade_option_chains.py --sandbox aapl`
 
-    The JSON file will have one key called 'quote' which will contain the underlying data.
-    Then each remaining key is a str representing the expiration date. The value will contain a list of all puts and calls
-    as dictionaries.
+**Note**: E*TRADE's sandbox doesn't actually produce correct option chains so
+this will return an error. The sandbox is still useful for debugging e.g. the
+OAuth stuff.
 
-    To recover the python object, use something like:
-        import json
-        with open('AAPL-YYYY-MM-DD.json','rt') as f: aapl=json.load(f)
-        
+The JSON file will have one key called 'quote' which will contain the underlying
+data. Then each remaining key is a str representing the expiration date. The
+value will contain a list of all puts and calls as dictionaries.
+
+To recover the python object, use something like:
+
+```python
+import json
+with open('AAPL_chains_YYYYMMDD-HHMMSS.json', 'rt') as f: aapl = json.load(f)
+```

--- a/etrade_option_chains.py
+++ b/etrade_option_chains.py
@@ -1,17 +1,35 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 
 import datetime as dt
 import argparse
+from json.decoder import JSONDecodeError
 import pyetrade
 import json
 import ast
+import os
 import sys
 
-''' 
+'''
     Grab the option expire dates and option chains for the specified symbol.
     Save as a JSON file
-    
+
 '''
+
+# FILL THESE IN WITH YOUR OAUTH KEYS AND SECRETS
+# See https://developer.etrade.com/getting-started
+OAUTH_KEYS = {
+    "sandbox": {
+        "consumer_key": "",
+        "consumer_secret": "",
+    },
+    "live": {
+        "consumer_key": "",
+        "consumer_secret": "",
+    }
+}
+
+# File to cache OAuth tokens so you don't have to re-authenticate each time
+ETRADE_OAUTH_FILE = ".etrade_oauth"
 
 def option_expire_dates_from_xml(q) -> list:
     """ Take the returned array of XML objects and create a list of dt.dates.
@@ -44,7 +62,9 @@ def get_all_option_chains(api, underlying_symbol) -> dict:
     for this_expiry_date in expiration_dates:
         q = api.get_option_chains(underlying_symbol, this_expiry_date)
         chains = q['OptionChainResponse']['OptionPair']
+        print(".", end="", flush=True) # progress
         rtn[this_expiry_date] = [i['Put'] for i in chains] + [i['Call'] for i in chains]
+    print()
     return rtn
 
 def strvals_to_real(q) -> dict:
@@ -72,34 +92,81 @@ def alter_quote_dict(quote) -> dict:
     rtn = strvals_to_real(quote['All'])
     rtn['dateTimeUTC'] = int(quote['dateTimeUTC'])
     for k in ('dateTime','quoteStatus','ahFlag','hasMiniOptions'):
-        rtn[k] = quote[k]
+        try:
+            rtn[k] = quote[k]
+        except KeyError: # hasMiniOptions missing in sandbox
+            continue
     rtn['securityType'] = quote['Product']['securityType']
     rtn['symbol'] = quote['Product']['symbol']
     return rtn
 
+def environment_key(use_sandbox) -> str:
+    return "sandbox" if use_sandbox else "live"
+
+def get_etrade_oauth(use_sandbox) -> dict:
+    try:
+        with open(ETRADE_OAUTH_FILE) as f:
+            tokens = json.load(f)
+            return tokens[environment_key(use_sandbox)]
+    except (KeyError, TypeError, FileNotFoundError, JSONDecodeError) as err:
+        print("Couldn't find/parse cached OAuth in {} ({}: {})".format(ETRADE_OAUTH_FILE, err))
+        return None
+
+# Save the token, merging in with existing tokens
+def save_etrade_oauth(token, use_sandbox) -> bool:
+    try:
+        try:
+            with open(ETRADE_OAUTH_FILE) as f:
+                tokens = json.load(f)
+        except FileNotFoundError:
+            tokens = {}
+        tokens[environment_key(use_sandbox)] = token
+        with open(os.open(ETRADE_OAUTH_FILE, os.O_CREAT | os.O_WRONLY, 0o600), "w") as f:
+            f.write(json.dumps(tokens))
+    except (KeyError, JSONDecodeError) as err:
+        print("Couldn't write cached OAuth in {} ({})".format(ETRADE_OAUTH_FILE, err))
+        sys.exit(1)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Grab all the option chains for the specified symbol',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--sandbox', help='use sandbox?', action=argparse.BooleanOptionalAction)
     parser.add_argument('symbol', help='symbol name', type=str)
     args = parser.parse_args()
-    
-# FILL THESE IN WITH YOUR KEY AND SECRET
-    consumer_key = ''
-    consumer_secret = ''
+    use_sandbox = args.sandbox
 
-    oauth = pyetrade.ETradeOAuth(consumer_key, consumer_secret)
-    print(oauth.get_request_token())
-    API_token = input('eTrade token: ')
-    oauth.get_access_token(API_token)
+    keys = OAUTH_KEYS[environment_key(use_sandbox)]
+    consumer_key = keys["consumer_key"]
+    consumer_secret = keys["consumer_secret"]
+
+    try:
+        token = get_etrade_oauth(use_sandbox)
+        # print("Got cached token: {}".format(token))
+        manager = pyetrade.authorization.ETradeAccessManager(
+            consumer_key,
+            consumer_secret,
+            token['oauth_token'],
+            token['oauth_token_secret']
+        )
+        manager.renew_access_token()
+    except Exception as err:
+        # print("Got {} when trying to get & renew cached OAuth tokens; getting new ones".format(err))
+        oauth = pyetrade.ETradeOAuth(consumer_key, consumer_secret)
+        print("Visit this URL and copy the five character token")
+        print(oauth.get_request_token())
+        API_token = input('E*TRADE token: ')
+        oauth.get_access_token(API_token)
+        token = oauth.access_token
+        save_etrade_oauth(token, use_sandbox)
+
     api = pyetrade.market.ETradeMarket(consumer_key, consumer_secret,
-                                       oauth.access_token['oauth_token'],
-                                       oauth.access_token['oauth_token_secret'],
-                                       dev=False)
+                                       token['oauth_token'],
+                                       token['oauth_token_secret'],
+                                       dev=use_sandbox)
 
     q = api.get_quote([args.symbol],require_earnings_date=True,resp_format='xml')     # a dict response
     quote = alter_quote_dict(q['QuoteResponse']['QuoteData'])
-    
+
     try:
         chains = get_all_option_chains(api, quote['symbol'])
     except Exception as err:
@@ -114,6 +181,7 @@ if __name__ == "__main__":
         converted_chain_list = [ strvals_to_real(v) for v in chain_list]
         converted_chains[str(expiry_date)] = converted_chain_list               # use str(expiry_date) because eventually this will be saved as JSON
 
-    json_filename = '%s chains %s.json' % (quote['symbol'], str(dt.date.today()))
+    json_filename = '{}_chains_{}.json'.format(quote['symbol'], dt.datetime.now().strftime("%Y%m%d-%H%M%S"))
     with open(json_filename, 'wt') as f:
         json.dump(converted_chains,f)
+    print("Wrote results to '{}' (size {})".format(json_filename, os.stat(json_filename).st_size))


### PR DESCRIPTION
Add a `--sandbox` flag to use the E*Trade sandbox. This helps debug auth but isn't much use for the options side.

Renew OAuth tokens by storing in a .etrade_oauth file. This allows you to run the program repeatedly without re-authenticating via the web each time.

Add a little more info to what's happening with progress dots.

Use python3 virtualenv (venv) to ease install and development.

Hope this helps!